### PR TITLE
Type the plugin structure itself

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-/** A PostHog plugin. `export default` it. */
+/** A PostHog plugin. */
 export interface Plugin {
     /** Ran when plugin */
     setupPlugin?: (meta: PluginMeta) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,19 @@
+/** A PostHog plugin. `export default` it. */
+export interface Plugin {
+    /** Ran when plugin */
+    setupPlugin?: (meta: PluginMeta) => void
+    /** Receive a single event and return it in its processed form. You can discard the event by returning null. */
+    processEvent?: (event: PluginEvent, meta: PluginMeta) => PluginEvent | null
+    /** Receive a batch of events and return it in its processed form. You can discard events by not including them in the returned array. You can also append additional events to the returned array. */
+    processEventBatch?: (eventBatch: PluginEvent[], meta: PluginMeta) => PluginEvent[]
+    /** Ran every minute, on the minute. */
+    runEveryMinute?: (meta: PluginMeta) => void
+    /** Ran every hour, on the hour. */
+    runEveryHour?: (meta: PluginMeta) => void
+    /** Ran every day, on midnight. */
+    runEveryDay?: (meta: PluginMeta) => void
+}
+
 export interface PluginEvent {
     distinct_id: string
     ip: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 /** A PostHog plugin. */
 export interface Plugin {
-    /** Ran when plugin */
+    /** Ran when the plugin is loaded by the PostHog plugin server. */
     setupPlugin?: (meta: PluginMeta) => void
     /** Receive a single event and return it in its processed form. You can discard the event by returning null. */
     processEvent?: (event: PluginEvent, meta: PluginMeta) => PluginEvent | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,9 @@ export interface Plugin {
     /** Ran when the plugin is loaded by the PostHog plugin server. */
     setupPlugin?: (meta: PluginMeta) => void
     /** Receive a single event and return it in its processed form. You can discard the event by returning null. */
-    processEvent?: (event: PluginEvent, meta: PluginMeta) => PluginEvent | null
+    processEvent?: (event: PluginEvent, meta: PluginMeta) => PluginEvent | null | Promise<PluginEvent | null>
     /** Receive a batch of events and return it in its processed form. You can discard events by not including them in the returned array. You can also append additional events to the returned array. */
-    processEventBatch?: (eventBatch: PluginEvent[], meta: PluginMeta) => PluginEvent[]
+    processEventBatch?: (eventBatch: PluginEvent[], meta: PluginMeta) => PluginEvent[] | Promise<PluginEvent[]>
     /** Ran every minute, on the minute. */
     runEveryMinute?: (meta: PluginMeta) => void
     /** Ran every hour, on the hour. */
@@ -42,6 +42,7 @@ export interface PluginAttachment {
 export interface PluginMeta {
     cache: CacheExtension
     storage: StorageExtension
+    config: Record<string, any>
 }
 
 export interface PluginConfigSchema {


### PR DESCRIPTION
This is basically so that when writing a plugin in you can do:

```JavaScript
import { Plugin } from '@posthog/plugin-scaffold

export default const myWhateverPlugin: Plugin {
    ...
}
```

and get autocompletion suggestions inside `myWhateverPlugin`, e.g. what arguments `processEvent` receives, that there exists `runEveryHour` etc.
Have to dig a bit more into this idea, but it'd really make writing plugins inside a code editor a much nicer experience.
Resolves #2.