### PR TITLE
Add types for selection option in plugin config

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,10 +49,9 @@ export interface PluginMeta {
     config: Record<string, any>
 }
 
-export interface PluginConfigSchema {
+interface PluginConfigStructure {
     key?: string
     name?: string
-    type?: 'string' | 'attachment'
     default?: string
     hint?: string
     markdown?: string
@@ -61,6 +60,16 @@ export interface PluginConfigSchema {
     secret?: boolean
 }
 
+interface PluginConfigDefault extends PluginConfigStructure {
+    type?: 'string' | 'attachment'
+} 
+
+interface PluginConfigSelection extends PluginConfigStructure {
+    type: 'selection'
+    options: string[]
+}
+
+export type PluginConfigSchema = PluginConfigDefault | PluginConfigSelection
 export interface CacheExtension {
     set: (key: string, value: unknown, ttlSeconds?: number) => Promise<void>
     get: (key: string, defaultValue: unknown) => Promise<unknown>

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,8 +65,8 @@ interface PluginConfigDefault extends PluginConfigStructure {
 } 
 
 interface PluginConfigSelection extends PluginConfigStructure {
-    type: 'selection'
-    options: string[]
+    type: 'choice'
+    choices: string[]
 }
 
 export type PluginConfigSchema = PluginConfigDefault | PluginConfigSelection

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ interface PluginConfigDefault extends PluginConfigStructure {
     type?: 'string' | 'attachment'
 } 
 
-interface PluginConfigSelection extends PluginConfigStructure {
+interface PluginConfigChoice extends PluginConfigStructure {
     type: 'choice'
     choices: string[]
 }


### PR DESCRIPTION
Typing necessary for https://github.com/PostHog/posthog/pull/3229

Allows for this:

<img width="416" alt="Screenshot 2021-02-07 at 12 51 14" src="https://user-images.githubusercontent.com/38760734/107146988-66010400-6943-11eb-80d3-4f1c51d9a4b4.png">

Happy to change the approach to the `PluginConfigSchema` type if there are suggestions.

Also see https://github.com/PostHog/taxonomy-plugin/pull/1 for an implementation of this.
