### PR TITLE
IP could be explicitly ignored and set to null / None

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type Properties = Record<string, any>
 
 export interface PluginEvent {
     distinct_id: string
-    ip: string
+    ip: string | null
     site_url: string
     team_id: number
     now: string


### PR DESCRIPTION
Companion to https://github.com/PostHog/posthog/pull/3464

Set explicitly to null since it'll always be passed, but either `null` or `string` unlike optional properties like `$set`, etc.