### PR TITLE
Add types for jobs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": false,
+    "singleQuote": true,
+    "printWidth": 120
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ type MetaInput = {
     config?: Record<string, any>
     attachments?: Record<string, PluginAttachment>
     global?: Record<string, any>
-    jobs?: Record<string, (opts?: any) => any>
+    jobs?: Record<string, JobFunction>
 }
 
 type JobRunnerObject<J extends Record<string, JobFunction>> = {


### PR DESCRIPTION
This is a WIP that adds types to an experimental syntax for jobs as described here: https://github.com/PostHog/plugin-server/pull/325

The following will work after this is merged:

```ts
import { CreatePluginMeta, MetaJobsInput } from '@posthog/plugin-scaffold'

type Meta = CreatePluginMeta<{
    config: {
        localhostIP: string
    }
    attachments: {
        maxmindMmdb?: PluginAttachment
    }
    global: {
        ipLookup?: Reader<Response>
    }
    jobs: {
        flushBatch: (ops: { batch: string[]; retryCount?: number }) => Promise<void>
    }
}>

export const jobs: MetaJobsInput<Meta> = {
    flushBatch: async ({ batch, retryCount = 0 }, { jobs }) => {
        const resp = await fetch('https://httpbin.org/post', {
            method: 'post',
            body: JSON.stringify(batch),
            headers: { 'Content-Type': 'application/json' },
        })
        if (resp.status !== 200) {
            if (retryCount > 5) {
                console.error('Could not post batch', batch)
                return
            }
            jobs.runIn(30, 'seconds').flushBatch({ batch, retryCount: retryCount + 1 })
        }
    },
}

export async function setupPlugin({ jobs }: Meta) {
    await jobs.runNow().flushBatch({ batch: [] })
}
```

The `meta.jobs` is fully typed. The `jobs` export unfortunately has to go through `MetaJobsInput<Meta>` when declaring (or it could be `Meta['__jobsInput']` perhaps?), as the output of `meta.jobs` has a different structure than the input. `meta.jobs` runs all the jobs via a wrapper like `jobs.runIn(30, 'minutes').flushBatch()`....

Obviously this should be merged only once we agree on the structure...
