### PR TITLE
Add ApiExtension and PostHogExtension types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "husky": ">=4",
         "lint-staged": ">=10.5.1",
+        "node-fetch": "^3.1.0",
         "prettier": "^2.2.1",
         "rimraf": "^3.0.0",
         "typescript": "^4.0.5"

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,7 +217,7 @@ export interface CursorUtils {
     increment: (key: string, incrementBy?: number) => Promise<number>
 }
 
-/** NB: The following should replace plugin-server/src/worker/vm/extensions/api.ts */
+/** NB: The following should replace types in plugin-server/src/worker/vm/extensions/api.ts */
 
 interface ApiMethodOptions {
     headers?: Headers

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,3 +215,27 @@ export interface CursorUtils {
     init: (key: string, initialValue?: number) => Promise<void>
     increment: (key: string, incrementBy?: number) => Promise<number>
 }
+
+/** NB: The following should replace plugin-server/src/worker/vm/extensions/api.ts */
+
+interface ApiMethodOptions {
+    headers?: Headers
+    data?: Record<string, any>
+    host?: string
+    projectApiKey?: string
+    personalApiKey?: string
+}
+
+export interface ApiExtension {
+    get(path: string, options?: ApiMethodOptions): Promise<Response>
+    post(path: string, options?: ApiMethodOptions): Promise<Response>
+    put(path: string, options?: ApiMethodOptions): Promise<Response>
+    delete(path: string, options?: ApiMethodOptions): Promise<Response>
+}
+
+/** NB: The following should replace DummyPostHog in plugin-server/src/worker/vm/extensions/posthog.ts */
+
+export interface PostHogExtension {
+    capture(event: string, properties?: Record<string, any>): Promise<void>
+    api: ApiExtension
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { City } from '@maxmind/geoip2-node'
+import { Response } from 'node-fetch'
 
 /** Input for a PostHog plugin. */
 export type PluginInput = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,6 +329,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -684,6 +689,13 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fetch-blob@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.3.tgz#a7dca4855e39d3e3c5a1da62d4ee335c37d26012"
+  integrity sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==
+  dependencies:
+    web-streams-polyfill "^3.0.3"
+
 figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -724,6 +736,13 @@ flatted@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1262,6 +1281,15 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+node-fetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.1.0.tgz#714f4922dc270239487654eaeeab86b8206cb52e"
+  integrity sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.2"
+    formdata-polyfill "^4.0.10"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -1896,6 +1924,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
+  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
The PostHog plugin dev experience is missing type definitions for the global `posthog` object. (I've been working around this by writing `declare const posthog: any` at the top of my plugin index files.)

<img width="455" alt="Screen Shot 2021-11-29 at 15 44 13" src="https://user-images.githubusercontent.com/4645779/143940365-c2ce7dff-39ff-40cb-a691-ab5f104c6136.png">

This PR:

- Adds type defs for `PostHogExtension` and `ApiExtension`, to keep them together with the other extension types.
- Adds `node-fetch` to devDependencies because it is required by `ApiExtension`.
  - Latest major version contains type definitions (no need for `@types/node-fetch`)
  - Requires nodejs >= 12.20.0 (shouldn't be a problem AFAIK)

Next steps - the goal is to have `posthog` correctly typed, automatically, in dev. Some ideas:

- A custom `d.ts` in the plugin template (e.g. https://github.com/PostHog/posthog-plugin-advanced-kit/). Thoughts @Twixes ?
- I thought adding `declare const posthog: PostHogExtension` to plugin server transforms would be useful, but since that's applied at compile time it won't make a difference in development, right?
- We merge and leave this for now and expect users to import the types from plugin-scaffold if they want to use them