### PR TITLE
Fix `RetryError` `name`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,1 +1,6 @@
-export class RetryError extends Error {}
+export class RetryError extends Error {
+    constructor(message?: string, options?: ErrorOptions) {
+        super(message, options)
+        this.name = "RetryError"
+    }
+}


### PR DESCRIPTION
While working on https://github.com/PostHog/posthog/pull/10187 I noticed that `new RetryError().toString()` results in `'Error'`. This makes it `'RetryError'` as one would expect.