### PR TITLE
Fix `RetryError` and add `nameWithAttempts`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,19 @@
 export class RetryError extends Error {
+    /** Set by the system. */
+    _attempt: number | undefined
+    /** Set by the system. */
+    _maxAttempts: number | undefined
+
     constructor(message?: string) {
         super(message)
         this.name = "RetryError"
+    }
+
+    get nameWithAttempts(): string {
+        return this._attempt && this._maxAttempts ? `${this.name} (attempt ${this._attempt}/${this._maxAttempts})` : this.name
+    }
+
+    toString(): string {
+        return this.message ? `${this.nameWithAttempts}: ${this.message}` : this.nameWithAttempts
     }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,6 @@
 export class RetryError extends Error {
-    constructor(message?: string, options?: ErrorOptions) {
-        super(message, options)
+    constructor(message?: string) {
+        super(message)
         this.name = "RetryError"
     }
 }


### PR DESCRIPTION
Fixes typing issue introduced in https://github.com/PostHog/plugin-scaffold/pull/40 and adds `nameWithAttempts` to `RetryError`.