### PR TITLE
Correct missing TS param in `README.md` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ npm install --save-dev @posthog/plugin-scaffold
 Then in your plugins:
 
 ```typescript
-import { PluginEvent, PluginMeta } from '@posthog/plugin-scaffold'
+import { PluginEvent, PluginInput, PluginMeta } from "@posthog/plugin-scaffold";
 
-export function processEvent(event: PluginEvent, meta: PluginMeta) {
+export function processEvent(event: PluginEvent, meta: PluginMeta<PluginInput>) {
     if (event.properties) {
         event.properties['hello'] = 'world'
     }


### PR DESCRIPTION
Without the extra `PluginInput` param in `PluginMeta<PluginInput>`, TypeScript generates a error from `PluginMeta` on it's own.

I needed to add this extra param to get it to compile.