### PR TITLE
fix: move `Element` from plugin-server to scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-scaffold",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Types and utilities for PostHog Plugins",
     "author": "PostHog <hey@posthog.com>",
     "repository": "github:PostHog/plugin-scaffold",

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,7 +111,7 @@ export interface ProcessedPluginEvent {
     /** The assigned UUIDT of the event. */
     uuid: string
     /** Person associated with the original distinct ID of the event. */
-    person?: PluginPerson
+    person: PluginPerson
     /** We process `$elements` out of `properties`, so we want to make sure we
      * maintain this in the processed event that we pass to plugins */
     elements?: Element[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export interface PluginEvent {
     /** The assigned UUIDT of the event. */
     uuid: string
     /** Person associated with the original distinct ID of the event. */
-    person: PluginPerson
+    person?: PluginPerson
 }
 
 /** Event after being processed by PostHog ingestion pipeline. */
@@ -111,7 +111,7 @@ export interface ProcessedPluginEvent {
     /** The assigned UUIDT of the event. */
     uuid: string
     /** Person associated with the original distinct ID of the event. */
-    person: PluginPerson
+    person?: PluginPerson
     /** We process `$elements` out of `properties`, so we want to make sure we
      * maintain this in the processed event that we pass to plugins */
     elements?: Element[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,21 @@ export type PluginMeta<T> = T extends { __internalMeta?: infer M } ? M : never
 
 export type Properties = Record<string, any>
 
+/** Usable Element model. */
+export interface Element {
+    text?: string
+    tag_name?: string
+    href?: string
+    attr_id?: string
+    attr_class?: string[]
+    nth_child?: number
+    nth_of_type?: number
+    attributes?: Record<string, any>
+    event_id?: number
+    order?: number
+    group_id?: number
+}
+
 /** Raw event received by PostHog ingestion pipeline */
 export interface PluginEvent {
     distinct_id: string


### PR DESCRIPTION
To allow the plugins to access Elements we need to have the typing here.
Previously this was using the DOM Element which is not correct.

Note we also have to make person optional for `PluginEvent`

This is the error we end up with

```
#38 [plugin-server 7/7] RUN yarn build
#38 30.87 src/utils/internal-metrics.ts(35,19): error TS2741: Property 'person' is missing in type '{ event: string; properties: { value: number; }; distinct_id: string; team_id: number; ip: null; site_url: string; now: string; uuid: string; }' but required in type 'PluginEvent'.
#38 30.87 src/worker/vm/upgrades/utils/utils.ts(154,47): error TS2345: Argument of type '{ uuid: string; team_id: number; distinct_id: string; properties: Record<string, any>; timestamp: string; now: string; event: string; ip: any; site_url: string; sent_at: string; }' is not assignable to parameter of type 'HistoricalExportEvent'.
#38 30.87   Property 'person' is missing in type '{ uuid: string; team_id: number; distinct_id: string; properties: Record<string, any>; timestamp: string; now: string; event: string; ip: any; site_url: string; sent_at: string; }' but required in type 'HistoricalExportEvent'.
#38 30.87 src/utils/event.ts(21,9): error TS2322: Type 'import("/code/plugin-server/src/types").Element[]' is not assignable to type 'Element[]'.
#38 30.87   Type 'Element' is missing the following properties from type 'Element': classList, className, clientHeight, clientLeft, and 159 more.
```