### PR TITLE
make exportEvents receive ProcessedPluginEvent[]

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface Plugin<Input extends PluginInput = {}> {
     /** DEPRECATED: Receive a batch of events and return it in its processed form. You can discard events by not including them in the returned array. You can also append additional events to the returned array. */
     processEventBatch?: (eventBatch: PluginEvent[], meta: Meta<Input>) => PluginEvent[] | Promise<PluginEvent[]>
     /** Receive a single non-snapshot event.  */
-    exportEvents?: (events: PluginEvent[], meta: Meta<Input>) => void | Promise<void>
+    exportEvents?: (events: ProcessedPluginEvent[], meta: Meta<Input>) => void | Promise<void>
     /** Receive a single processed event. */
     onEvent?: (event: ProcessedPluginEvent, meta: Meta<Input>) => void | Promise<void>
     /** Receive a single snapshot (session recording) event. */


### PR DESCRIPTION
exportEvents is just an abstraction over onEvent. It takes ProcessedPluginEvent, not PluginEvent. Ran into this problem while working on the big query plugin.