### PR TITLE
Remove person properties from ProcessedPluginEvent

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -110,8 +110,6 @@ export interface ProcessedPluginEvent {
     $set_once?: Properties
     /** The assigned UUIDT of the event. */
     uuid: string
-    /** Person associated with the original distinct ID of the event. */
-    person?: PluginPerson
     /** We process `$elements` out of `properties`, so we want to make sure we
      * maintain this in the processed event that we pass to plugins */
     elements?: Element[]


### PR DESCRIPTION
Given that we don't current expose person properties, I figured we should update the types to remove the `person` property from the `ProcessedPluginEvent` type altogether. 

**Question**: are person properties available at the processEvent stage? (If not, we should remove from `PluginEvent` as well)