### PR TITLE
chore(exportEvents): add handlesLargeBatches setting

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -11,14 +11,14 @@ export type PluginInput = {
 }
 
 export type PluginSettings = {
-    /** Some plugins incurr high costs for small batches, e.g. S3. In these cases 
+    /** Some plugins incur high costs for small batches, e.g. S3. In these cases 
         we want to signal that the plugin would prefer larger batches. There are other
         plugins that may not be written to handle large batches, for these we will want 
         to keep batches small to not break their behaviour.
         
         Defaults to `false`.
     */
-    handlesLargeBatches: boolean
+    handlesLargeBatches?: boolean
 }
 
 /** A PostHog plugin. */
@@ -27,7 +27,8 @@ export interface Plugin<Input extends PluginInput = {}> {
     setupPlugin?: (meta: Meta<Input>) => void
     /** Ran when the plugin is unloaded by the PostHog plugin server. */
     teardownPlugin?: (meta: Meta<Input>) => void
-    /** Return settings to instruct the plugin-server how to call the plugin. e.g. what is the maximum events batch size it could be called with. */
+    /** Experimental: Return settings to instruct the plugin-server how to call the plugin. 
+        e.g. what is the maximum events batch size it could be called with. */
     getSettings?: (meta: Meta<Input>) => PluginSettings
     /** Receive a single non-snapshot event and return it in its processed form. You can discard the event by returning null. */
     processEvent?: (event: PluginEvent, meta: Meta<Input>) => PluginEvent | null | Promise<PluginEvent | null>

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,17 +10,30 @@ export type PluginInput = {
     metrics?: Record<string, AllowedMetricsOperations>
 }
 
+export type PluginSettings = {
+    /** Some plugins incurr high costs for small batches, e.g. S3. In these cases 
+        we want to signal that the plugin would prefer larger batches. There are other
+        plugins that may not be written to handle large batches, for these we will want 
+        to keep batches small to not break their behaviour.
+        
+        Defaults to `false`.
+    */
+    handlesLargeBatches: boolean
+}
+
 /** A PostHog plugin. */
 export interface Plugin<Input extends PluginInput = {}> {
     /** Ran when the plugin is loaded by the PostHog plugin server. */
     setupPlugin?: (meta: Meta<Input>) => void
     /** Ran when the plugin is unloaded by the PostHog plugin server. */
     teardownPlugin?: (meta: Meta<Input>) => void
+    /** Return settings to instruct the plugin-server how to call the plugin. e.g. what is the maximum events batch size it could be called with. */
+    getSettings?: (meta: Meta<Input>) => PluginSettings
     /** Receive a single non-snapshot event and return it in its processed form. You can discard the event by returning null. */
     processEvent?: (event: PluginEvent, meta: Meta<Input>) => PluginEvent | null | Promise<PluginEvent | null>
     /** DEPRECATED: Receive a batch of events and return it in its processed form. You can discard events by not including them in the returned array. You can also append additional events to the returned array. */
     processEventBatch?: (eventBatch: PluginEvent[], meta: Meta<Input>) => PluginEvent[] | Promise<PluginEvent[]>
-    /** Receive a single non-snapshot event.  */
+    /** Receive a batch of non-snapshot event. */
     exportEvents?: (events: ProcessedPluginEvent[], meta: Meta<Input>) => void | Promise<void>
     /** Receive a single processed event. */
     onEvent?: (event: ProcessedPluginEvent, meta: Meta<Input>) => void | Promise<void>

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,9 @@ export type PluginInput = {
 }
 
 export type PluginSettings = {
-    /** Some plugins incur high costs for small batches, e.g. S3. In these cases 
+    /** Experimental: 
+    
+        Some plugins incur high costs for small batches, e.g. S3. In these cases 
         we want to signal that the plugin would prefer larger batches. There are other
         plugins that may not be written to handle large batches, for these we will want 
         to keep batches small to not break their behaviour.


### PR DESCRIPTION
To accommodate plugins that incur costs for small batches, we add a setting such that the plugin will receive larger batches of events.

For these plugins, if they do in fact have limits on their operations they will need to handle this detail internally.