### PR TITLE
chore(session-recordings): remove onSnapshot typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-scaffold",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "Types and utilities for PostHog Plugins",
     "author": "PostHog <hey@posthog.com>",
     "repository": "github:PostHog/plugin-scaffold",

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,8 +40,6 @@ export interface Plugin<Input extends PluginInput = {}> {
     exportEvents?: (events: ProcessedPluginEvent[], meta: Meta<Input>) => void | Promise<void>
     /** Receive a single processed event. */
     onEvent?: (event: ProcessedPluginEvent, meta: Meta<Input>) => void | Promise<void>
-    /** Receive a single snapshot (session recording) event. */
-    onSnapshot?: (event: ProcessedPluginEvent, meta: Meta<Input>) => void | Promise<void>
     /** Ran every minute, on the minute. */
     runEveryMinute?: (meta: Meta<Input>) => void
     /** Ran every hour, on the hour. */


### PR DESCRIPTION
This is related to the corresponding documentation
[here](https://github.com/PostHog/posthog.com/pull/5159).

We no longer run `onSnapshot` on snapshot events and haven't done so for
some time.