### PR TITLE
feat: Plugins future types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,27 +1,17 @@
 import { City } from '@maxmind/geoip2-node'
-import { Response, Headers } from 'node-fetch'
+import { Response, Headers, RequestInfo, RequestInit } from 'node-fetch'
 
 /** Input for a PostHog plugin. */
 export type PluginInput = {
     config?: Record<string, any>
     attachments?: Record<string, PluginAttachment | undefined>
     global?: Record<string, any>
+    /** DEPRECATED */
     jobs?: Record<string, JobOptions>
+    /** DEPRECATED */
     metrics?: Record<string, AllowedMetricsOperations>
 }
 
-export type PluginSettings = {
-    /** Experimental: 
-    
-        Some plugins incur high costs for small batches, e.g. S3. In these cases 
-        we want to signal that the plugin would prefer larger batches. There are other
-        plugins that may not be written to handle large batches, for these we will want 
-        to keep batches small to not break their behaviour.
-        
-        Defaults to `false`.
-    */
-    handlesLargeBatches?: boolean
-}
 
 /** A PostHog plugin. */
 export interface Plugin<Input extends PluginInput = {}> {
@@ -29,31 +19,36 @@ export interface Plugin<Input extends PluginInput = {}> {
     setupPlugin?: (meta: Meta<Input>) => void
     /** Ran when the plugin is unloaded by the PostHog plugin server. */
     teardownPlugin?: (meta: Meta<Input>) => void
-    /** Experimental: Return settings to instruct the plugin-server how to call the plugin. 
-        e.g. what is the maximum events batch size it could be called with. */
+    /** DEPRECATED */
     getSettings?: (meta: Meta<Input>) => PluginSettings
-    /** Receive a single non-snapshot event and return it in its processed form. You can discard the event by returning null. */
+    /** Used for filtering events, return True to keep the event and False to drop it. */
+    filterEvent?: (event: PostHogEvent, meta: Meta<Input>) => boolean
+    /** Used for modifying events, return the updated event */
+    modifyEvent?: (event: PostHogEvent, meta: Meta<Input>) => PostHogEvent
+    /** DEPRECATED: use filterEvent or modifyEvent */
     processEvent?: (event: PluginEvent, meta: Meta<Input>) => PluginEvent | null | Promise<PluginEvent | null>
-    /** DEPRECATED: Receive a batch of events and return it in its processed form. You can discard events by not including them in the returned array. You can also append additional events to the returned array. */
+    /** DEPRECATED: use filterEvent or modifyEvent */ 
     processEventBatch?: (eventBatch: PluginEvent[], meta: Meta<Input>) => PluginEvent[] | Promise<PluginEvent[]>
-    /** Receive a batch of non-snapshot event. */
+    /** DEPRECATED: use composeWebhook */
     exportEvents?: (events: ProcessedPluginEvent[], meta: Meta<Input>) => void | Promise<void>
-    /** Receive a single processed event. */
-    onEvent?: (event: ProcessedPluginEvent, meta: Meta<Input>) => void | Promise<void>
-    /** Ran every minute, on the minute. */
+    /** DEPRECATED: use composeWebhook */
+    onEvent?: (event: ProcessedPluginEvent | PostHogEvent, meta: Meta<Input>) => void | Promise<void>
+    /** Used for exporting a single event */
+    composeWebhook?: (event: PostHogEvent, meta: Meta<Input>) => [RequestInfo, RequestInit]
+    /** DEPRECATED:  */
     runEveryMinute?: (meta: Meta<Input>) => void
-    /** Ran every hour, on the hour. */
+    /** DEPRECATED:  */
     runEveryHour?: (meta: Meta<Input>) => void
-    /** Ran every day, on midnight. */
+    /** DEPRECATED:  */
     runEveryDay?: (meta: Meta<Input>) => void
-    /** Asynchronous jobs that can be scheduled. */
+    /** DEPRECATED */
     jobs?: {
         [K in keyof Meta<Input>['jobs']]: (
             opts: Parameters<Meta<Input>['jobs'][K]>[0],
             meta: Meta<Input>
         ) => void | Promise<void>
     }
-    /** Metrics about plugin performance that can be set by plugin devs */
+    /** DEPRECATED */
     metrics?: {
         [K in keyof Meta<Input>['metrics']]: AllowedMetricsOperations
     }
@@ -61,83 +56,28 @@ export interface Plugin<Input extends PluginInput = {}> {
     __internalMeta?: Meta<Input>
 }
 
-export enum MetricsOperation {
-    Sum = 'sum',
-    Min = 'min',
-    Max = 'max',
-}
-
-export type AllowedMetricsOperations = MetricsOperation.Sum | MetricsOperation.Max | MetricsOperation.Min
 
 export type PluginMeta<T> = T extends { __internalMeta?: infer M } ? M : never
 
 export type Properties = Record<string, any>
 
-/** Usable Element model. */
-export interface Element {
-    text?: string
-    tag_name?: string
-    href?: string
-    attr_id?: string
-    attr_class?: string[]
-    nth_child?: number
-    nth_of_type?: number
-    attributes?: Record<string, any>
-    event_id?: number
-    order?: number
-    group_id?: number
-}
-
-/** Raw event received by PostHog ingestion pipeline */
-export interface PluginEvent {
-    distinct_id: string
-    ip: string | null
-    site_url: string
-    team_id: number
-    now: string
-    event: string
-    sent_at?: string
-    properties?: Properties
-    timestamp?: string
-    offset?: number
-    /** Person properties update (override). */
-    $set?: Properties
-    /** Person properties update (if not set). */
-    $set_once?: Properties
+/** We're moving to a single PostHogEvent model use this in any future apps/plugins 
+*/
+export interface PostHogEvent {
     /** The assigned UUIDT of the event. */
     uuid: string
-    /** Person associated with the original distinct ID of the event. */
-    person?: PluginPerson
-}
-
-/** Event after being processed by PostHog ingestion pipeline. */
-export interface ProcessedPluginEvent {
-    distinct_id: string
-    ip: string | null
     team_id: number
+    distinct_id: string
     event: string
-    properties: Properties
     timestamp: string
-    /** Person properties update (override). */
-    $set?: Properties
-    /** Person properties update (if not set). */
-    $set_once?: Properties
-    /** The assigned UUIDT of the event. */
-    uuid: string
-    /** Person associated with the original distinct ID of the event. */
-    person?: PluginPerson
-    /** We process `$elements` out of `properties`, so we want to make sure we
-     * maintain this in the processed event that we pass to plugins */
-    elements?: Element[]
+    /** Optionally contains
+     * $ip - for ip address
+     * $set - for person properties to set
+     * $set_once - for person properties to set if not already set
+     */
+    properties: Properties // contains $ip, $set and $set_once
 }
 
-/** Person exposed to the plugin. */
-export interface PluginPerson {
-    uuid: string
-    team_id: number
-    properties: Properties
-    created_at: string
-}
 
 export interface PluginAttachment {
     content_type: string
@@ -146,52 +86,23 @@ export interface PluginAttachment {
 }
 
 interface BasePluginMeta {
+    // DEPRECATED
     cache: CacheExtension
+    // DEPRECATED
     storage: StorageExtension
+    // DEPRECATED
     geoip: GeoIPExtension
     config: Record<string, any>
     global: Record<string, any>
     attachments: Record<string, PluginAttachment | undefined>
+    // DEPRECATED
     jobs: Record<string, (opts: any) => JobControls>
+    // DEPRECATED
     metrics: Record<string, Partial<FullMetricsControls>>
+    // DEPRECATED
     utils: UtilsExtension
 }
 
-type JobOptions = Record<string, any> | undefined
-
-type JobControls = {
-    runNow: () => Promise<void>
-    runIn: (duration: number, unit: string) => Promise<void>
-    runAt: (date: Date) => Promise<void>
-}
-
-interface MetricsControlsIncrement {
-    increment: (value: number) => Promise<void>
-}
-
-interface MetricsControlsMax {
-    max: (value: number) => Promise<void>
-}
-
-interface MetricsControlsMin {
-    min: (value: number) => Promise<void>
-}
-
-type FullMetricsControls = MetricsControlsIncrement & MetricsControlsMax & MetricsControlsMin
-
-type MetricsControls<V> = V extends MetricsOperation.Sum
-    ? MetricsControlsIncrement
-    : V extends MetricsOperation.Max
-    ? MetricsControlsMax
-    : MetricsControlsMin
-
-type MetaMetricsFromMetricsOptions<J extends Record<string, string>> = {
-    [K in keyof J]: MetricsControls<J[K]>
-}
-
-type MetaJobsFromJobOptions<J extends Record<string, JobOptions>> = {
-    [K in keyof J]: (opts: J[K]) => JobControls
-}
 
 export interface Meta<Input extends PluginInput = {}> extends BasePluginMeta {
     attachments: Input['attachments'] extends Record<string, PluginAttachment | undefined>
@@ -199,9 +110,11 @@ export interface Meta<Input extends PluginInput = {}> extends BasePluginMeta {
         : Record<string, PluginAttachment | undefined>
     config: Input['config'] extends Record<string, any> ? Input['config'] : Record<string, any>
     global: Input['global'] extends Record<string, any> ? Input['global'] : Record<string, any>
+    // DEPRECATED
     jobs: Input['jobs'] extends Record<string, JobOptions>
         ? MetaJobsFromJobOptions<Input['jobs']>
         : Record<string, (opts: any) => JobControls>
+    // DEPRECATED
     metrics: Input['metrics'] extends Record<string, AllowedMetricsOperations>
         ? MetaMetricsFromMetricsOptions<Input['metrics']>
         : Record<string, FullMetricsControls>
@@ -234,12 +147,156 @@ export interface PluginConfigChoice extends PluginConfigStructure {
 
 export type PluginConfigSchema = PluginConfigDefault | PluginConfigChoice
 
-/** Additional cache set/get options. */
+export interface ConsoleExtension {
+    log: (...args: unknown[]) => void
+    error: (...args: unknown[]) => void
+    debug: (...args: unknown[]) => void
+    info: (...args: unknown[]) => void
+    warn: (...args: unknown[]) => void
+}
+
+// Not yet available
+export interface PluginPerson {
+    uuid: string
+    team_id: number
+    properties: Properties
+    created_at: string
+}
+
+// *** EVERYTHING BELOW IS DEPRECATED ***
+
+// DEPRECATED
+export enum MetricsOperation {
+    Sum = 'sum',
+    Min = 'min',
+    Max = 'max',
+}
+
+// DEPRECATED
+export type AllowedMetricsOperations = MetricsOperation.Sum | MetricsOperation.Max | MetricsOperation.Min
+
+// DEPRECATED
+export type PluginSettings = {
+    /** Experimental: 
+    
+        Some plugins incur high costs for small batches, e.g. S3. In these cases 
+        we want to signal that the plugin would prefer larger batches. There are other
+        plugins that may not be written to handle large batches, for these we will want 
+        to keep batches small to not break their behaviour.
+        
+        Defaults to `false`.
+    */
+    handlesLargeBatches?: boolean
+}
+
+/** DEPRECATED: Use PostHogEvent.properties['$elements_chain'] */
+export interface Element {
+    text?: string
+    tag_name?: string
+    href?: string
+    attr_id?: string
+    attr_class?: string[]
+    nth_child?: number
+    nth_of_type?: number
+    attributes?: Record<string, any>
+    event_id?: number
+    order?: number
+    group_id?: number
+}
+
+/** DEPRECATED: Use PostHogEvent */
+export interface PluginEvent {
+    distinct_id: string
+    ip: string | null
+    site_url: string
+    team_id: number
+    now: string
+    event: string
+    sent_at?: string
+    properties?: Properties
+    timestamp?: string
+    offset?: number
+    /** Person properties update (override). */
+    $set?: Properties
+    /** Person properties update (if not set). */
+    $set_once?: Properties
+    /** The assigned UUIDT of the event. */
+    uuid: string
+    /** Person associated with the original distinct ID of the event. */
+    person?: PluginPerson
+}
+/** DEPRECATED: Use PostHogEvent */
+export interface ProcessedPluginEvent {
+    distinct_id: string
+    ip: string | null
+    team_id: number
+    event: string
+    properties: Properties
+    timestamp: string
+    /** Person properties update (override). */
+    $set?: Properties
+    /** Person properties update (if not set). */
+    $set_once?: Properties
+    /** The assigned UUIDT of the event. */
+    uuid: string
+    /** Person associated with the original distinct ID of the event. */
+    person?: PluginPerson
+    /** We process `$elements` out of `properties`, so we want to make sure we
+     * maintain this in the processed event that we pass to plugins */
+    elements?: Element[]
+}
+
+// DEPRECATED
+type JobOptions = Record<string, any> | undefined
+
+// DEPRECATED
+type JobControls = {
+    runNow: () => Promise<void>
+    runIn: (duration: number, unit: string) => Promise<void>
+    runAt: (date: Date) => Promise<void>
+}
+
+// DEPRECATED
+interface MetricsControlsIncrement {
+    increment: (value: number) => Promise<void>
+}
+
+// DEPRECATED
+interface MetricsControlsMax {
+    max: (value: number) => Promise<void>
+}
+
+// DEPRECATED
+interface MetricsControlsMin {
+    min: (value: number) => Promise<void>
+}
+
+// DEPRECATED
+type FullMetricsControls = MetricsControlsIncrement & MetricsControlsMax & MetricsControlsMin
+
+// DEPRECATED
+type MetricsControls<V> = V extends MetricsOperation.Sum
+    ? MetricsControlsIncrement
+    : V extends MetricsOperation.Max
+    ? MetricsControlsMax
+    : MetricsControlsMin
+
+// DEPRECATED
+type MetaMetricsFromMetricsOptions<J extends Record<string, string>> = {
+    [K in keyof J]: MetricsControls<J[K]>
+}
+
+// DEPRECATED
+type MetaJobsFromJobOptions<J extends Record<string, JobOptions>> = {
+    [K in keyof J]: (opts: J[K]) => JobControls
+}
+// DEPRECATED
 export interface CacheOptions {
     /** Whether input should be JSON-stringified/parsed. */
     jsonSerialize?: boolean
 }
 
+// DEPRECATED
 export interface CacheExtension {
     set: (key: string, value: unknown, ttlSeconds?: number, options?: CacheOptions) => Promise<void>
     get: (key: string, defaultValue: unknown, options?: CacheOptions) => Promise<unknown>
@@ -252,35 +309,30 @@ export interface CacheExtension {
     lrem: (key: string, count: number, elementKey: string) => Promise<number>
 }
 
+// DEPRECATED
 export interface StorageExtension {
     set: (key: string, value: unknown) => Promise<void>
     get: (key: string, defaultValue: unknown) => Promise<unknown>
     del: (key: string) => Promise<void>
 }
 
-export interface ConsoleExtension {
-    log: (...args: unknown[]) => void
-    error: (...args: unknown[]) => void
-    debug: (...args: unknown[]) => void
-    info: (...args: unknown[]) => void
-    warn: (...args: unknown[]) => void
-}
-
+// DEPRECATED
 export interface GeoIPExtension {
     locate: (ip: string) => Promise<City | null>
 }
 
+// DEPRECATED
 export interface UtilsExtension {
     cursor: CursorUtils
 }
 
+// DEPRECATED
 export interface CursorUtils {
     init: (key: string, initialValue?: number) => Promise<void>
     increment: (key: string, incrementBy?: number) => Promise<number>
 }
 
-/** NB: The following should replace types in plugin-server/src/worker/vm/extensions/api.ts */
-
+// DEPRECATED
 interface ApiMethodOptions {
     headers?: Headers
     data?: Record<string, any>
@@ -289,6 +341,7 @@ interface ApiMethodOptions {
     personalApiKey?: string
 }
 
+// DEPRECATED
 export interface ApiExtension {
     get(path: string, options?: ApiMethodOptions): Promise<Response>
     post(path: string, options?: ApiMethodOptions): Promise<Response>
@@ -296,8 +349,7 @@ export interface ApiExtension {
     delete(path: string, options?: ApiMethodOptions): Promise<Response>
 }
 
-/** NB: The following should replace DummyPostHog in plugin-server/src/worker/vm/extensions/posthog.ts */
-
+// DEPRECATED
 export interface PostHogExtension {
     capture(event: string, properties?: Record<string, any>): Promise<void>
     api: ApiExtension


### PR DESCRIPTION
There are a couple of changes proposed here:
1. Marked things as deprecated that we've decided not to support in the future. Note that I didn't yet remove anything as we'll need to update the plugins and code to make sure it can be removed from here later
2. Created a single `PostHogEvent` that all plugins will take and potentially return. This would make things simpler for both us and plugin developers. Currently it's a bit convoluted because of how we do timestamp processing (which we could just do before the first processEvent plugins) and elements parsing (which we can skip doing all together). Note that by using a single type we could use the same filterEvent plugins in the beginning and in front of `composeWebhook` plugins (if we later want to)
3. Plugins shouldn't include anything async, so created new functions that don't allow that.
4. Split `processEvent` into two separate functions
   1. `filterEvent` which allows ingestion filtering. We'd run first it first to decides if we should keep the event or drop it
   2. `modifyEvent` which allows event transformation - updating the PostHogEvent - e.g. adding `day_of_the_week` property from unixtimestamp
5. Instead of `onEvent` we'll have `composeWebhook` so we're taking the sending the webhook / fetch call outside of the plugins making it possible for us to better handle retries etc.


What I didn't change:
1. we don't want users to define plugins with multiple functions, so we should restrict that with types, but it's not trivial with combination of plugin-server code, so I left it as is for now
2. we might want to have some filtering happen in a different way before composeWebhook, currently it allows returning `null` to make migrations easier



Related: https://posthog.slack.com/archives/C02E3BKC78F/p1695901794213689

