### PR TITLE
Preserve comments to enable deprecation warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "lib": ["es2020"],
         "skipLibCheck": true,
         "declaration": true,
-        "removeComments": true,
+        "removeComments": false,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "moduleResolution": "node",


### PR DESCRIPTION
Problem: right now, types/interfaces are being marked as deprecated, but then when the .d.ts files are generated, the comments are removed.  By preserving the comments, we surface the deprecation warnings when this library is used.

Since this package is intended to be used as a library for plugins, presumably the plugin importing this package will strip the comments via minification.   Also, this should only be server-side code, so package size is not a concern.