### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -86,8 +86,7 @@ jobs:
               id: yarn-upgrade-posthog
               run: |
                   cd posthog/
-                  OUTGOING_VERSION=$(jq '.dependencies["@posthog/plugin-scaffold"]' package.json -r)
-                  echo "::set-output name=outgoing-version::$OUTGOING_VERSION"
+                  echo "outgoing-version=$(jq '.dependencies["@posthog/plugin-scaffold"]' package.json -r)" >> "$GITHUB_OUTPUT"
                   for i in $(seq 1 $RETRY_TIMES); do
                       # Retry loop because of npm being _eventually_ consistent
                       if yarn upgrade @posthog/plugin-scaffold@${{ env.REPO_VERSION }}; then

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -49,8 +49,6 @@ jobs:
             - name: Publish the package in the npm registry
               run: npm publish --access public
               env:
-                  DATABASE_URL: 'postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres'
-                  REDIS_URL: 'redis://localhost'
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Create GitHub release

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -110,7 +110,7 @@ jobs:
               id: changelog
               run: |
                   cd plugin-scaffold
-                  PULL_REQUESTS=$(git log v${{ steps.yarn-upgrade.outputs.outgoing-version }}..v${{ env.REPO_VERSION }} --pretty=format:%s --grep='^.*\d*)$' --reverse | sed -e 's;(#;(PostHog/plugin-scaffold#;' -e 's/^/- /')
+                  PULL_REQUESTS=$(git log v${{ steps.yarn-upgrade-posthog.outputs.outgoing-version }}..v${{ env.REPO_VERSION }} --pretty=format:%s --grep='^.*\d*)$' --reverse | sed -e 's;(#;(PostHog/plugin-scaffold#;' -e 's/^/- /')
                   # Escape characters that are problematic for GitHub Actions set-output
                   PULL_REQUESTS="${PULL_REQUESTS//'%'/'%25'}"
                   PULL_REQUESTS="${PULL_REQUESTS//$'\n'/'%0A'}"
@@ -131,8 +131,9 @@ jobs:
                   body: |
                       ## Changes
                       plugin-scaffold version ${{ env.REPO_VERSION }} has been released. This updates PostHog to use it.
-                      https://github.com/PostHog/plugin-scaffold/compare/v${{ steps.yarn-upgrade.outputs.outgoing-version }}...v${{ env.REPO_VERSION }}:
+                      https://github.com/PostHog/plugin-scaffold/compare/v${{ steps.yarn-upgrade-posthog.outputs.outgoing-version }}...v${{ env.REPO_VERSION }}:
                       ${{ steps.changelog.outputs.pull-requests }}
+
             - name: Output pull request result
               run: |
                   echo "PostHog pull request for plugin-scaffold version ${{ env.REPO_VERSION }} ready: ${{ steps.main-repo-pr.outputs.pull-request-url }}"


### PR DESCRIPTION
Several things are broken, but the biggest thing is [set-output is deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)