### PR TITLE
Update properties element in PostHogEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-scaffold",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Types and utilities for PostHog Plugins",
     "author": "PostHog <hey@posthog.com>",
     "repository": "github:PostHog/plugin-scaffold",

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,8 @@ export type PluginMeta<T> = T extends { __internalMeta?: infer M } ? M : never
 
 export type Properties = Record<string, any>
 
+type PostHogEventProperties = { '$elements_chain' : string, [id: string]: any };
+
 /** We're moving to a single PostHogEvent model use this in any future apps/plugins 
 */
 export interface PostHogEvent {
@@ -82,7 +84,7 @@ export interface PostHogEvent {
      * $set_once - for person properties to set if not already set
      * $elements_chain - for autocapture elements chain
      */
-    properties: Properties
+    properties: PostHogEventProperties
 }
 
 


### PR DESCRIPTION
As part of the move to `composeWebhook`, plugins will be using events of type `PostHogEvent` instead of `ProcessedPluginEvent`.  `PostHogEvent`s are created [here](https://github.com/PostHog/posthog/blob/6904d40228ba7cd9516a4d8a99ab7baeb38e4363/plugin-server/src/utils/event.ts#L79) from `RawClickHouseEvent` ([definition](https://github.com/PostHog/posthog/blob/6904d40228ba7cd9516a4d8a99ab7baeb38e4363/plugin-server/src/types.ts#L608)) and will always have `$elements_chain` set on its `properties` object (potentially with other elements, but possibly not).